### PR TITLE
Add test for deterministic ordering

### DIFF
--- a/repo2file/__main__.py
+++ b/repo2file/__main__.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
 import os
 import argparse
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except Exception:  # pragma: no cover - fallback when tqdm is missing
+    def tqdm(iterable, **_):
+        """Fallback tqdm that simply returns the iterable."""
+        return iterable
 
 def collect_source_files(directory, extensions):
     """
@@ -17,6 +22,8 @@ def collect_source_files(directory, extensions):
         for file in files:
             if any(file.endswith(ext) for ext in extensions):
                 matching_files.append(os.path.join(root, file))
+
+    matching_files.sort()
                 
     collected_code = ""
     # Process each file with a progress bar

--- a/tests/test_repo2file.py
+++ b/tests/test_repo2file.py
@@ -207,3 +207,22 @@ def test_main_exception_write(monkeypatch, tmp_path, capsys):
     
     captured = capsys.readouterr().out
     assert "Error writing to output file" in captured
+
+
+def test_collect_source_files_stable_order(tmp_path):
+    """Repeated calls should yield the same file ordering."""
+    # Create multiple files in arbitrary order
+    files = [
+        tmp_path / "b.py",
+        tmp_path / "a.py",
+    ]
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    files.append(sub / "c.py")
+    for idx, f in enumerate(files):
+        f.write_text(f"file {idx}", encoding="utf-8")
+
+    first = collect_source_files(str(tmp_path), [".py"])
+    second = collect_source_files(str(tmp_path), [".py"])
+    assert first == second
+


### PR DESCRIPTION
## Summary
- add a small tqdm fallback so repo runs without dependency installed
- ensure files in `collect_source_files` are sorted
- test that collecting source files twice yields the same order

## Testing
- `PYTHONPATH=$(pwd) pytest -q -o addopts=""`