### PR TITLE
Ensure deterministic file ordering in collector

### DIFF
--- a/repo2file/__main__.py
+++ b/repo2file/__main__.py
@@ -23,7 +23,10 @@ def collect_source_files(directory, extensions):
         for file in files:
             if any(file.endswith(ext) for ext in extensions):
                 matching_files.append(os.path.join(root, file))
-                
+
+    # Sort to guarantee deterministic ordering of files across runs
+    matching_files.sort()
+
     collected_code = ""
     # Process each file with a progress bar
     for file_path in tqdm(matching_files, desc="Collecting files", unit="file"):

--- a/tests/test_repo2file.py
+++ b/tests/test_repo2file.py
@@ -79,6 +79,28 @@ def test_ignore_virtualenv(tmp_path):
     assert "print('Should be ignored')" not in result
 
 
+def test_deterministic_ordering(tmp_path):
+    """
+    Verify that files are processed in a deterministic, sorted order.
+    """
+    # Create files in an unsorted order.
+    file_b = tmp_path / "b.py"
+    file_b.write_text("print('B')", encoding="utf-8")
+
+    file_a = tmp_path / "a.py"
+    file_a.write_text("print('A')", encoding="utf-8")
+
+    result = collect_source_files(str(tmp_path), [".py"])
+
+    header_a = f"# --- {file_a} ---"
+    header_b = f"# --- {file_b} ---"
+
+    assert header_a in result
+    assert header_b in result
+    # Ensure the header for 'a.py' appears before the header for 'b.py'.
+    assert result.index(header_a) < result.index(header_b)
+
+
 def test_no_matching_files(tmp_path):
     """
     Test that if there are no files matching the extensions, an empty string is returned.


### PR DESCRIPTION
## Summary
- guarantee deterministic processing order of files in `collect_source_files`
- test deterministic ordering

## Testing
- `PYTHONPATH=. pytest -q -o addopts=""`